### PR TITLE
fix include error, declare AVCodec* as const, and update the example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,104 +25,105 @@ No more words to say, just take a look at transocding example!
 // and place it in av namespace
 namespace av
 {
-template<typename... Args>
-void writeLog(LogLevel level, internal::SourceLocation&& loc, std::string_view fmt, Args&&... args) noexcept
+void writeLog(LogLevel level, internal::SourceLocation&& loc, std::string msg) noexcept
 {
-    std::cerr << loc.toString() << ": " << av::internal::format(fmt, std::forward<Args>(args)...) << std::endl;
+	std::cerr << loc.toString() << ": " << msg << std::endl;
 }
 }// namespace av
 
 template<typename... Args>
 void println(std::string_view fmt, Args&&... args) noexcept
 {
-    std::cout << av::internal::format(fmt, std::forward<Args>(args)...) << std::endl;
+	std::cout << av::internal::format(fmt, std::forward<Args>(args)...) << std::endl;
 }
 
 template<typename Return>
 Return assertExpected(av::Expected<Return>&& expected) noexcept
 {
-    if (!expected)
-    {
-        std::cerr << " === Expected failure == \n"
-                  << expected.errorString() << std::endl;
-        exit(EXIT_FAILURE);
-    }
+	if (!expected)
+	{
+		std::cerr << " === Expected failure == \n"
+		          << expected.errorString() << std::endl;
+		exit(EXIT_FAILURE);
+	}
 
-    if constexpr (std::is_same_v<Return, void>)
-        return;
-    else
-        return expected.value();
+	if constexpr (std::is_same_v<Return, void>)
+		return;
+	else
+		return expected.value();
 }
 
 int main(int argc, const char* argv[])
 {
-    if (argc < 3)
-    {
-        std::cout << "Usage: transcode <input> <output>" << std::endl;
-        return 0;
-    }
+	if (argc < 3)
+	{
+		std::cout << "Usage: transcode <input> <output>" << std::endl;
+		return 0;
+	}
 
-    std::string_view input(argv[1]);
-    std::string_view output(argv[2]);
+	std::string_view input(argv[1]);
+	std::string_view output(argv[2]);
 
-    av_log_set_level(AV_LOG_VERBOSE);
+	av_log_set_level(AV_LOG_VERBOSE);
 
-    auto reader = assertExpected(av::StreamReader::create(input, true));
+	auto reader = assertExpected(av::StreamReader::create(input, true));
 
-    av::Frame frame;
+	av::Frame frame;
 
-    auto writer = assertExpected(av::StreamWriter::create(output));
+	auto writer = assertExpected(av::StreamWriter::create(output));
 
-    auto width     = reader->frameWidth();
-    auto height    = reader->frameHeight();
-    auto framerate = reader->framerate();
-    framerate      = av_inv_q(framerate);
-    auto pixFmt    = reader->pixFmt();
+	{
+		auto width     = reader->frameWidth();
+		auto height    = reader->frameHeight();
+		auto framerate = reader->framerate();
+		framerate      = av_inv_q(framerate);
+		auto pixFmt    = reader->pixFmt();
 
-    av::OptValueMap codecOpts = {{"preset", "fast"}, {"crf", 29}};
+		av::OptValueMap codecOpts = {{"preset", "fast"}, {"crf", 29}};
 
-    assertExpected(writer->addVideoStream(AV_CODEC_ID_H264, width, height, 
-                                          pixFmt, framerate, std::move(codecOpts)));
+		assertExpected(writer->addVideoStream(AV_CODEC_ID_H264, width, height, pixFmt, framerate, std::move(codecOpts)));
+	}
 
-    auto channels = reader->channels();
-    auto rate     = reader->sampleRate();
-    auto format   = reader->sampleFormat();
-    auto bitRate  = 128 * 1024;
+	{
+		auto channels = reader->channels();
+		auto rate     = reader->sampleRate();
+		auto format   = reader->sampleFormat();
+		auto bitRate  = 128 * 1024;
 
-    assertExpected(writer->addAudioStream(AV_CODEC_ID_AAC, channels, format, 
-                                          rate, channels, rate, bitRate));
+		assertExpected(writer->addAudioStream(AV_CODEC_ID_AAC, channels, format, rate, channels, rate, bitRate));
+	}
 
-    assertExpected(writer->open());
+	assertExpected(writer->open());
 
-    int video_n = 0;
-    int audio_n = 0;
-    for (;;)
-    {
-        if (!assertExpected(reader->readFrame(frame)))
-            break;
+	int video_n = 0;
+	int audio_n = 0;
+	for (;;)
+	{
+		if (!assertExpected(reader->readFrame(frame)))
+			break;
 
-        if (frame.type() == AVMEDIA_TYPE_VIDEO)
-        {
-            if (video_n % 100 == 0)
-                println("Writing video {} frame", video_n);
+		if (frame.type() == AVMEDIA_TYPE_VIDEO)
+		{
+			if (video_n % 100 == 0)
+				println("Writing video {} frame", video_n);
 
-            assertExpected(writer->write(frame, 0));
+			assertExpected(writer->write(frame, 0));
 
-            video_n++;
-        }
-        else if (frame.type() == AVMEDIA_TYPE_AUDIO)
-        {
-            if (audio_n % 100 == 0)
-                println("Writing audio {} frame", audio_n);
+			video_n++;
+		}
+		else if (frame.type() == AVMEDIA_TYPE_AUDIO)
+		{
+			if (audio_n % 100 == 0)
+				println("Writing audio {} frame", audio_n);
 
-            assertExpected(writer->write(frame, 1));
+			assertExpected(writer->write(frame, 1));
 
-            audio_n++;
-        }
-    }
+			audio_n++;
+		}
+	}
 
-    println("Encoded {} video {} audio frames", video_n, audio_n);
+	println("Encoded {} video {} audio frames", video_n, audio_n);
 
-    return 0;
+	return 0;
 }
 ```

--- a/av/Decoder.hpp
+++ b/av/Decoder.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <av/Frame.hpp>
+#include <av/Packet.hpp>
 #include <av/common.hpp>
 
 namespace av
@@ -13,7 +14,7 @@ class Decoder : NoCopyable
 	{}
 
 public:
-	static Expected<Ptr<Decoder>> create(AVCodec* codec, AVStream* stream, AVRational framerate = {})
+	static Expected<Ptr<Decoder>> create(const AVCodec* codec, AVStream* stream, AVRational framerate = {})
 	{
 		if (!av_codec_is_decoder(codec))
 			RETURN_AV_ERROR("{} is not a decoder", codec->name);

--- a/av/InputFormat.hpp
+++ b/av/InputFormat.hpp
@@ -92,7 +92,7 @@ public:
 private:
 	Expected<void> findBestStream(AVMediaType type) noexcept
 	{
-		AVCodec* dec = nullptr;
+		const AVCodec* dec = nullptr;
 		int stream_i = av_find_best_stream(ic_, type, -1, -1, &dec, 0);
 		if (stream_i == AVERROR_STREAM_NOT_FOUND)
 			RETURN_AV_ERROR("Failed to find {} stream in '{}'", av_get_media_type_string(type), url_);


### PR DESCRIPTION
I'm not really sure why but it seems like Packet.hpp wasn't included in Decoder.hpp for some reason. Also AVCodec* needed to be declared as const, this might be due to version differences in libav, I am using a pretty recent version cloned from their github a few weeks ago. Feel free to ignore this if you want to stick with an older version i guess